### PR TITLE
Mark AI Retakes as Pro feature

### DIFF
--- a/docs/workspace/side-panels.md
+++ b/docs/workspace/side-panels.md
@@ -8,7 +8,10 @@ Many different panels can be accessed from the menu at the side of the applicati
 General settings that apply to the entire track or group, such as which singer to use, which language to sing in, and default note settings.
 
 ### 2. AI Retakes
-Allows the creation and selection of alternate "takes", both for pitch and timbre.
+
+!!! note "Pro Feature - AI Retakes"
+
+    Allows the creation and selection of alternate "takes", both for pitch and timbre.
 
 ### 3. Note Properties
 Individual settings to customize the selected note(s), such as modifying pitch transitions, vibrato, or phoneme timing.


### PR DESCRIPTION
Absent from the Basic editor, and noted as such in the [release notes](https://dreamtonics.com/en/synthesizer-v-studio-1-7-0-update-ai-retakes-feature/).

I think I've done the `!!! note` thing properly, but please double-check!

![image](https://user-images.githubusercontent.com/16479013/213017466-ada942de-ce5d-43df-b505-a4655d72d6c5.png)

![image](https://user-images.githubusercontent.com/16479013/213017259-4e97469d-fbe4-4188-954f-9ed3a15603b2.png)
