### PR TITLE
Use `pymdownx.keys` to format key combinations

### DIFF
--- a/docs/quickstart/creating-notes.md
+++ b/docs/quickstart/creating-notes.md
@@ -5,12 +5,12 @@ Note creation varies based on the selected tool. Generally, the pointer tool wil
 ![Piano Roll Tools](/img/quickstart/piano-roll-tools.png)
 
 ### Pointer Tool
-With the pointer tool (ALT + 1) selected, double click (without releasing the left button after the second click) and drag in the piano roll to create a note of the desired length.
+With the pointer tool (++alt+1++) selected, double click (without releasing the left button after the second click) and drag in the piano roll to create a note of the desired length.
 
 ![Adding Notes With the Pointer Tool](/img/quickstart/add-note-pointer.png)
 
 ### Pencil Tool
 
-With the pencil tool (ALT + 2) selected, drag anywhere in the note area to create a note of the desired length.
+With the pencil tool (++alt+2++) selected, drag anywhere in the note area to create a note of the desired length.
 
 ![Adding Notes With the Pencil Tool](/img/quickstart/add-note-pencil.png)

--- a/docs/quickstart/editing-notes.md
+++ b/docs/quickstart/editing-notes.md
@@ -4,15 +4,15 @@
 
 Notes can be selected by clicking on them. To select multiple notes at once, use the pointer tool to drag a bounding box around them.
 
-Select all notes in the current track or group with CTRL + A.
+Select all notes in the current track or group with ++ctrl+a++.
 
 ![Piano Roll Tools](/img/quickstart/piano-roll-tools.png)
 
 ![Selecting Multiple Notes](/img/quickstart/pencil-bounding-box.png)
 
-Multiple notes can also be selected or deselected by clicking on them individually while holding CTRL.
+Multiple notes can also be selected or deselected by clicking on them individually while holding ++ctrl++.
 
-A continuous sequence of notes can be selected by clicking the first note, holding SHIFT, and clicking the last note.
+A continuous sequence of notes can be selected by clicking the first note, holding ++shift++, and clicking the last note.
 
 ### Modifying Notes
 

--- a/docs/quickstart/entering-lyrics.md
+++ b/docs/quickstart/entering-lyrics.md
@@ -3,9 +3,9 @@
 ![Note Lyrics and Special Symbols](/img/quickstart/note-lyrics.png)
 
 ### 1. Lyric Entry
-Double click on a note to enter a lyric. Press Enter or click outside the note to confirm, or press ESC to cancel the change.
+Double click on a note to enter a lyric. Press ++enter++ or click outside the note to confirm, or press ++esc++ to cancel the change.
 
-Pressing TAB will confirm the change and advance to the next note, while CTRL + TAB will move to the previous note.
+Pressing ++tab++ will confirm the change and advance to the next note, while ++ctrl+tab++ will move to the previous note.
 
 ### 2. Syllable Break
 Use the plus sign (+) to distribute a multi-syllable word across multiple notes.

--- a/docs/stylesheets/theme.css
+++ b/docs/stylesheets/theme.css
@@ -2,3 +2,13 @@
   --md-primary-fg-color: #7db235;
   --md-accent-fg-color: #85BC38;
 }
+
+.keys {
+  padding-left: 0.12em;
+  padding-right: 0.12em;
+}
+
+.keys .key-mouse-wheel:before {
+  content: "🖱";
+  padding-right: 0.4em
+}

--- a/docs/workspace/layout.md
+++ b/docs/workspace/layout.md
@@ -17,13 +17,13 @@ A panel for viewing and modifying [parameter curves](../../parameters/parameters
 Buttons for opening the various [side panels](side-panels.md).
 
 ### Workspace Navigation
-Aside from using the scrollbars on the bottom and left borders, you can conveniently navigate in all directions using mouse wheel + key combinations.
+Aside from using the scrollbars on the bottom and left borders, you can conveniently navigate in all directions using ++"modifier key"+mouse-wheel++ combinations.
 
 |Shortcut|Description|
 |---|---|
-|Mousewheel|Vertical scroll|
-|SHIFT + Mousewheel|Horizontal scroll|
-|CTRL + Mousewheel|Horizontal zoom (mouse-centered)|
+|++mouse-wheel++|Vertical scroll|
+|++shift+mouse-wheel++|Horizontal scroll|
+|++ctrl+mouse-wheel++|Horizontal zoom (mouse-centered)|
 
 At the time of writing there is no support for vertical zoom.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,3 +74,6 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.superfences
+  - pymdownx.keys:
+      key_map:
+        mouse-wheel: "Mouse wheel"


### PR DESCRIPTION
https://facelessuser.github.io/pymdown-extensions/extensions/keys/

Hopefully it improves readability, and doesn't distract too much from the content.

Example of how it looks like:
(The `^` in front of Ctrl is a bit weird, but it makes sense with the other modifier keys.)

![image](https://user-images.githubusercontent.com/16479013/213032434-fc885d03-0725-440d-84b6-0e962490421a.png)
